### PR TITLE
Dry run concordium transactions first

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "ccdeth_relayer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccdeth_relayer"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/relayer/src/db.rs
+++ b/relayer/src/db.rs
@@ -1131,7 +1131,6 @@ async fn insert_into_db(
                             token_id: cis2::TokenId::new_unchecked(vec![0u8; 8]),
                         };
                         let update = concordium_contracts::StateUpdate::Deposit(deposit);
-                        // TODO estimate execution energy.
                         if let Some(tx) = bridge_manager.make_state_update_tx(&update).await? {
                             txs.push((event.tx_hash, tx));
                         }

--- a/relayer/src/db.rs
+++ b/relayer/src/db.rs
@@ -1132,9 +1132,9 @@ async fn insert_into_db(
                         };
                         let update = concordium_contracts::StateUpdate::Deposit(deposit);
                         // TODO estimate execution energy.
-                        let tx =
-                            bridge_manager.make_state_update_tx(bridge_manager.max_energy, &update);
-                        txs.push((event.tx_hash, tx));
+                        if let Some(tx) = bridge_manager.make_state_update_tx(&update).await? {
+                            txs.push((event.tx_hash, tx));
+                        }
                         deposits.push((event.tx_hash, id.low_u64(), amount, depositor, root_token));
                     }
                     ethereum::EthEvent::TokenMapped {
@@ -1152,8 +1152,9 @@ async fn insert_into_db(
                             child: child_token,
                         };
                         let update = concordium_contracts::StateUpdate::TokenMap(map);
-                        let tx = bridge_manager.make_state_update_tx(100_000.into(), &update);
-                        txs.push((event.tx_hash, tx));
+                        if let Some(tx) = bridge_manager.make_state_update_tx(&update).await? {
+                            txs.push((event.tx_hash, tx));
+                        }
                         maps.push((root_token, child_token, name.clone(), decimals));
                     }
                     ethereum::EthEvent::TokenUnmapped {

--- a/relayer/src/ethereum.rs
+++ b/relayer/src/ethereum.rs
@@ -286,7 +286,7 @@ where
                 log::debug!("New mapping for ERC20 token at {:#x}.", decoded.root_token);
                 let contract = crate::erc20::Erc20::new(decoded.root_token, client.clone());
                 let name = contract
-                    .name()
+                    .symbol()
                     .call()
                     .await
                     .context("Unable to get name of a token.")?;


### PR DESCRIPTION
## Purpose

Dry run Concordium state updates to check whether the operation has already completed, and to estimate energy.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.