### PR TITLE
Frontend/next merkle root

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Unreleased
+
+### Changes
+- For withdrawals, the expected time of the next merkle root, i.e. when the next round of withdrawals will be ready for approval, is now displayed instead of statically showing 10 minute processing time.
+
+## 0.1.0
+
+Initial version.

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,7 @@
 import Layout from "@components/organisms/layout/Layout";
 import connectors from "@config/connectors";
 import useMediaQuery from "@hooks/use-media-query";
+import moment from "moment";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
@@ -12,6 +13,25 @@ import GlobalStyles from "src/theme/global";
 import { QueryRouter } from "src/types/config";
 import Web3Provider from "web3-react";
 import "../styles/globals.css";
+
+moment.locale("en", {
+    relativeTime: {
+        future: "in ~%s",
+        past: "%s ago",
+        s: "1s",
+        ss: "%ss",
+        m: "1m",
+        mm: "%dm",
+        h: "1h",
+        hh: "%dh",
+        d: "1d",
+        dd: "%dd",
+        M: "1M",
+        MM: "%dM",
+        y: "1Y",
+        yy: "%dY",
+    },
+});
 
 const queryClient = new QueryClient();
 

--- a/frontend/pages/withdraw/overview.tsx
+++ b/frontend/pages/withdraw/overview.tsx
@@ -7,12 +7,16 @@ import { routes } from "src/constants/routes";
 import { Components } from "src/api-query/__generated__/AxiosClient";
 import useEthWallet from "@hooks/use-eth-wallet";
 import { useRouter } from "next/router";
+import { useNextMerkleRoot } from "src/api-query/queries";
+import moment from "moment";
 
 const WithdrawOverview: NextPage = () => {
     const hasApproval = useRef(false);
     const { ccdContext } = useCCDWallet();
     const { context } = useEthWallet();
     const { prefetch } = useRouter();
+    const { data, isLoading } = useNextMerkleRoot();
+    const nextMerkleTime = data !== undefined ? moment(data * 1000).fromNow() : undefined;
 
     const {
         withdraw: ccdWithdraw,
@@ -91,7 +95,7 @@ const WithdrawOverview: NextPage = () => {
         }
     };
 
-    return <TransferOverview handleSubmit={onSubmit} isWithdraw />;
+    return <TransferOverview handleSubmit={onSubmit} isWithdraw nextMerkleRoot={{ isLoading, time: nextMerkleTime }} />;
 };
 
 export default WithdrawOverview;

--- a/frontend/src/api-query/queries.ts
+++ b/frontend/src/api-query/queries.ts
@@ -31,7 +31,7 @@ export const useWatchWithdraw = (params?: WatchWithdrawParams, options?: WatchWi
         async () => {
             const client = await getClient();
             if (!client) throw new Error("Client not initialized.");
-            const { data } = await client?.watch_withdraw_tx(params);
+            const { data } = await client.watch_withdraw_tx(params);
             return data;
         },
         {
@@ -69,7 +69,7 @@ export const useWatchDeposit = (params?: WatchDepositParams, options?: WatchDepo
         async () => {
             const client = await getClient();
             if (!client) throw new Error("Client not initialized.");
-            const { data } = await client?.watch_deposit_tx(params);
+            const { data } = await client.watch_deposit_tx(params);
             return data;
         },
         {
@@ -106,7 +106,7 @@ export const useWalletTransactions = () => {
             if (!wallet) {
                 return undefined;
             }
-            const { data } = await client?.wallet_txs({ wallet });
+            const { data } = await client.wallet_txs({ wallet });
             return data;
         },
         { refetchInterval: QUERY_UPDATE_INTERVAL }
@@ -137,7 +137,7 @@ export const useTokens = () => {
         async () => {
             const client = await getClient();
             if (!client) throw new Error("Client not initialized.");
-            const { data } = await client?.list_tokens();
+            const { data } = await client.list_tokens();
             return data;
         },
         { refetchOnWindowFocus: false }
@@ -158,7 +158,7 @@ export const useEthMerkleProof = (params: Partial<MerkleProofParams>, enabled = 
             if (params.event_id === undefined || params.tx_hash === undefined)
                 throw new Error("Should not be enabled with partial params");
 
-            const { data } = await client?.eth_merkle_proof(params as MerkleProofParams);
+            const { data } = await client.eth_merkle_proof(params as MerkleProofParams);
             return data;
         },
         {
@@ -170,6 +170,24 @@ export const useEthMerkleProof = (params: Partial<MerkleProofParams>, enabled = 
                 }
                 return MERKLE_UPDATE_INTERVAL;
             },
+        }
+    );
+};
+
+export const useNextMerkleRoot = () => {
+    const { getClient } = useAxiosClient();
+
+    return useQuery(
+        [CacheKeys.EthMerkleProof],
+        async () => {
+            const client = await getClient();
+
+            if (!client) throw new Error("Client not initialized.");
+            const { data } = await client.expected_merkle_root_update();
+            return data;
+        },
+        {
+            refetchInterval: MERKLE_UPDATE_INTERVAL,
         }
     );
 };

--- a/frontend/src/components/templates/history/History.tsx
+++ b/frontend/src/components/templates/history/History.tsx
@@ -77,27 +77,6 @@ const History = ({ depositSelected }: Props) => {
     }, [depositSelected, isMobile]);
 
     useEffect(() => {
-        moment.locale("en", {
-            relativeTime: {
-                future: "in %s",
-                past: "%s ago",
-                s: "1s",
-                ss: "%ss",
-                m: "1m",
-                mm: "%dm",
-                h: "1h",
-                hh: "%dh",
-                d: "1d",
-                dd: "%dd",
-                M: "1M",
-                MM: "%dM",
-                y: "1Y",
-                yy: "%dY",
-            },
-        });
-    }, []);
-
-    useEffect(() => {
         // NextJS router is only available on the client, so we use `useEffect` to defer running this until the first client side render.
         if (!context.account) {
             replace(routes.deposit.path);

--- a/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
+++ b/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
@@ -34,6 +34,7 @@ type BaseProps = {
 };
 type WithdrawProps = BaseProps & {
     isWithdraw: true;
+    nextMerkleRoot: { isLoading: boolean; time: string | undefined };
 };
 type DepositProps = BaseProps & {
     isWithdraw?: false;
@@ -133,9 +134,14 @@ export const TransferOverview: React.FC<Props> = (props) => {
                         fontColor="TitleText"
                         fontLetterSpacing="0"
                     >
-                        {isWithdraw
-                            ? "Withdraw should take up to 10 minutes to complete."
-                            : "Deposit should take up to 5 minutes to complete."}
+                        {props.isWithdraw &&
+                            !props.nextMerkleRoot.isLoading &&
+                            !props.nextMerkleRoot.time &&
+                            "Could not get an estimated processing time"}
+                        {props.isWithdraw &&
+                            props.nextMerkleRoot.time &&
+                            `Withdrawal expected to be ready for approval ${props.nextMerkleRoot.time}`}
+                        {!isWithdraw && "Deposit should take up to 5 minutes to complete."}
                     </Text>
                     <div style={{ marginTop: 12 }} />
                     <Text

--- a/frontend/src/constants/CacheKeys.ts
+++ b/frontend/src/constants/CacheKeys.ts
@@ -6,4 +6,5 @@ export const CacheKeys = {
     CCDBalance: "Cache.CCDBalance",
     TokenBalance: "Cache.TokenBalance",
     EthMerkleProof: "Cache.EthMerkleProof",
+    NextMerkleRoot: "Cache.NextMerkleRoot",
 };


### PR DESCRIPTION
## Purpose

Add a more precise estimate to when a withdrawal can be expected to be bridged to the selected ethereum account.

## Changes

- Query API for next merkle root, and display this in the withdraw overview
- Added a changelog, as the initial test version has now been deployed

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
