### PR TITLE
Add no-std option

### DIFF
--- a/.github/workflows/concordium-contracts.yaml
+++ b/.github/workflows/concordium-contracts.yaml
@@ -89,3 +89,27 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           cargo test --manifest-path concordium_contracts/bridge-manager/Cargo.toml
           cargo test --manifest-path concordium_contracts/cis2-bridgeable/Cargo.toml
+
+  compile-no-std:
+    name: compile:no-std
+    runs-on: ubuntu-latest
+    needs: "lint_clippy"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install nightly toolchain with check available
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Run cargo build with no-std
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          cargo +nightly concordium build -e --manifest-path concordium_contracts/bridge-manager/Cargo.toml -- --no-default-features --features wee_alloc
+          cargo +nightly concordium build -e --manifest-path concordium_contracts/cis2-bridgeable/Cargo.toml -- --no-default-features --features wee_alloc

--- a/.github/workflows/concordium-contracts.yaml
+++ b/.github/workflows/concordium-contracts.yaml
@@ -94,6 +94,15 @@ jobs:
     name: compile:no-std
     runs-on: ubuntu-latest
     needs: "lint_clippy"
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+
+        crates:
+          - concordium_contracts/bridge-manager/Cargo.toml
+          - concordium_contracts/cis2-bridgeable/Cargo.toml
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -108,8 +117,9 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
 
-      - name: Run cargo build with no-std
-        run: |
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-          cargo +nightly concordium build -e --manifest-path concordium_contracts/bridge-manager/Cargo.toml -- --no-default-features --features wee_alloc
-          cargo +nightly concordium build -e --manifest-path concordium_contracts/cis2-bridgeable/Cargo.toml -- --no-default-features --features wee_alloc
+      - name: Run cargo check with no-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee_alloc
+

--- a/concordium_contracts/bridge-manager/Cargo.lock
+++ b/concordium_contracts/bridge-manager/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "concordium-cis2"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79565da947685f4e4a81e544a94fa00fe947a5638536f4a34070611898e50bd"
+checksum = "a2d6e0f1833635faa71c0712b1526fec66262451b48898f82296336da433ec41"
 dependencies = [
  "concordium-std",
  "primitive-types",
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.0.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd703828c828f07ec9e074455dfdc104f1eb3f17fa3a3d828e241da1279062"
+checksum = "10c679c55679b73fd8b2b5cd986ec4c6010e05b18fff93e0319d97319f4e9b16"
 dependencies = [
  "concordium-contracts-common-derive",
  "fnv",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-std"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a778a27f3f75fb7d82c42cc594b7901d8bf65030ddbb89c8ef6e80685d056d59"
+checksum = "a1cd1507ef21deffc81933f567770784f0d1208c68356f664f588e06d9ad647a"
 dependencies = [
  "concordium-contracts-common",
  "concordium-std-derive",
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-std-derive"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42753e76b002cb242a1c04a15d9bc8b4830c73b69f8b1b5efada009e297222ef"
+checksum = "0a8dcf85dc8dcd70140e53fa05ae96c5a2a436f82da2ca07a8610469f2bf4ddb"
 dependencies = [
  "concordium-contracts-common",
  "proc-macro2",
@@ -113,9 +113,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "memory_units"

--- a/concordium_contracts/bridge-manager/Cargo.toml
+++ b/concordium_contracts/bridge-manager/Cargo.toml
@@ -7,11 +7,12 @@ version = "0.1.0"
 
 [features]
 default = ["std"]
-std = ["concordium-std/std", "concordium-cis2/std"]
+std = ["concordium-std/std", "concordium-cis2/std", "wee_alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-cis2 = {version = "2.0.0", features = ["std", "u256_amount"]}
-concordium-std = {version = "5.0.0", default-features = false}
+concordium-cis2 = {version = "3.0.0", default-features = false, features = ["u256_amount"]}
+concordium-std = {version = "6.0.1", default-features = false}
 
 [dev-dependencies]
 primitive-types = {version = "0.11", default-features = false}

--- a/concordium_contracts/cis2-bridgeable/Cargo.lock
+++ b/concordium_contracts/cis2-bridgeable/Cargo.lock
@@ -20,15 +20,14 @@ version = "0.1.0"
 dependencies = [
  "concordium-cis2",
  "concordium-std",
- "hex",
  "primitive-types",
 ]
 
 [[package]]
 name = "concordium-cis2"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79565da947685f4e4a81e544a94fa00fe947a5638536f4a34070611898e50bd"
+checksum = "a2d6e0f1833635faa71c0712b1526fec66262451b48898f82296336da433ec41"
 dependencies = [
  "concordium-std",
  "primitive-types",
@@ -36,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.0.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd703828c828f07ec9e074455dfdc104f1eb3f17fa3a3d828e241da1279062"
+checksum = "10c679c55679b73fd8b2b5cd986ec4c6010e05b18fff93e0319d97319f4e9b16"
 dependencies = [
  "concordium-contracts-common-derive",
  "fnv",
@@ -58,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-std"
-version = "5.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a778a27f3f75fb7d82c42cc594b7901d8bf65030ddbb89c8ef6e80685d056d59"
+checksum = "a1cd1507ef21deffc81933f567770784f0d1208c68356f664f588e06d9ad647a"
 dependencies = [
  "concordium-contracts-common",
  "concordium-std-derive",
@@ -69,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "concordium-std-derive"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42753e76b002cb242a1c04a15d9bc8b4830c73b69f8b1b5efada009e297222ef"
+checksum = "0a8dcf85dc8dcd70140e53fa05ae96c5a2a436f82da2ca07a8610469f2bf4ddb"
 dependencies = [
  "concordium-contracts-common",
  "proc-macro2",

--- a/concordium_contracts/cis2-bridgeable/Cargo.toml
+++ b/concordium_contracts/cis2-bridgeable/Cargo.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 
 [features]
 default = ["std"]
-std = ["concordium-std/std", "concordium-cis2/std"]
+std = ["concordium-std/std", "concordium-cis2/std", "wee_alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-cis2 = {version = "2.0.0", features = ["std", "u256_amount"]}
-concordium-std = {version = "5.0.0", default-features = false}
-hex = "0.4"
+concordium-cis2 = {version = "3.0.0", default-features = false, features = ["u256_amount"]}
+concordium-std = {version = "6.0.1", default-features = false}
 primitive-types = {version = "0.11", default-features = false}
 
 [lib]

--- a/concordium_contracts/cis2-bridgeable/src/lib.rs
+++ b/concordium_contracts/cis2-bridgeable/src/lib.rs
@@ -1350,6 +1350,8 @@ mod tests {
     const ADDRESS_1: Address = Address::Account(ACCOUNT_1);
     const ACCOUNT_2: AccountAddress = AccountAddress([2u8; 32]);
     const ADDRESS_2: Address = Address::Account(ACCOUNT_2);
+    const HASH: [u8; 32] = [57_u8; 32];
+    const HASH2: [u8; 32] = [33_u8; 32];
 
     const TOKEN_METADATA_URL: &str = "https://example.com/metadata";
 
@@ -1665,7 +1667,7 @@ mod tests {
         // and parameter.
         let init_params = SetMetadataUrlParams {
             url:  TOKEN_METADATA_URL.to_string(),
-            hash: Some([1_u8; 32]),
+            hash: Some(HASH),
         };
         let parameter_bytes = to_bytes(&init_params);
         ctx.set_parameter(&parameter_bytes);
@@ -1693,9 +1695,9 @@ mod tests {
         );
 
         claim_eq!(
-            hex::encode(state.metadata_url.hash.unwrap()),
-            "01".repeat(32),
-            "Token metadata url is not matching"
+            state.metadata_url.hash.unwrap(),
+            HASH,
+            "Token metadata hash is not matching"
         );
 
         // Setup the context
@@ -1705,7 +1707,7 @@ mod tests {
         let new_metadata_url = "https://example.com/new/metadata/params";
         let change_params = SetMetadataUrlParams {
             url:  new_metadata_url.to_string(),
-            hash: Some([57_u8; 32]),
+            hash: Some(HASH2),
         };
         let parameter_bytes = to_bytes(&change_params);
         ctx.set_parameter(&parameter_bytes);
@@ -1740,8 +1742,8 @@ mod tests {
         );
 
         claim_eq!(
-            hex::encode(metadata_hash.unwrap()),
-            "39".repeat(32),
+            metadata_hash.unwrap(),
+            HASH2,
             "Token metadata hash is not matching"
         );
 
@@ -1751,7 +1753,7 @@ mod tests {
                     token_id:     TOKEN_ID,
                     metadata_url: MetadataUrl {
                         url:  new_metadata_url.to_string(),
-                        hash: Some([57_u8; 32]),
+                        hash: Some(HASH2),
                     },
                 })
             )),


### PR DESCRIPTION
## Purpose

close #36 

## Changes

- Enable the smart contracts to be complied with `no-std` option.
- Update concordium-std to 6.0.1
- Update concordium-cis2 to 3.0.0

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
