### PR TITLE
Remove or lax rounding where applicable

### DIFF
--- a/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
+++ b/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
@@ -23,7 +23,6 @@ import { useMemo, useState } from "react";
 import { QueryRouter } from "src/types/config";
 import isDeposit from "src/helpers/checkTransaction";
 import { useGetTransactionToken } from "@hooks/use-transaction-token";
-import { formatAmount } from "src/helpers/number";
 import { useWalletTransactions } from "src/api-query/queries";
 import { ethers } from "ethers";
 
@@ -216,8 +215,7 @@ export const TransferProgress: React.FC<Props> = (props) => {
                                     </Text>
                                     <Text fontSize="16" fontColor="White" fontWeight="bold">
                                         <>
-                                            {formatAmount(decimalAmount)}{" "}
-                                            {isWithdraw ? token?.ccd_name : token?.eth_name}
+                                            {decimalAmount} {isWithdraw ? token?.ccd_name : token?.eth_name}
                                         </>
                                     </Text>
                                 </>

--- a/frontend/src/components/templates/transfer/Transfer.tsx
+++ b/frontend/src/components/templates/transfer/Transfer.tsx
@@ -43,7 +43,6 @@ import {
     StyledWalletDisplay,
     SwapLink,
 } from "./Transfer.style";
-import { formatAmount } from "src/helpers/number";
 import { ethers } from "ethers";
 
 interface ChainType {
@@ -120,6 +119,8 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
         query: { reset = false },
         isReady,
         prefetch,
+        replace,
+        pathname,
     } = useRouter() as QueryRouter<TransferRouteQuery>;
     const { context, connect, disconnect } = useEthWallet();
     const { ccdContext, connectCCD, disconnectCCD } = useCCDWallet();
@@ -240,6 +241,7 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
     useEffect(() => {
         if (reset && isReady) {
             clearTransactionFlow();
+            replace(pathname);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [reset, isReady]);
@@ -301,7 +303,7 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
                         <Dropdown onClick={dropdownHandler}>
                             <Image src={ArrowDownIcon.src} alt="dropdown icon" height="12" width="12" />
                         </Dropdown>
-                        <Button variant="max" onClick={() => setInputAmount(tokenBalance?.toString() ?? "")}>
+                        <Button variant="max" onClick={() => setInputAmount(decimalTokenBalance ?? "")}>
                             <Text fontSize="10" fontWeight="light">
                                 Max
                             </Text>
@@ -341,7 +343,7 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
                         />
                         {isLoggedIn && token && decimalTokenBalance && (
                             <Text style={{ alignSelf: "flex-end" }} fontColor="Balance" fontSize="10">
-                                Balance:&nbsp;{formatAmount(decimalTokenBalance)}
+                                Balance:&nbsp;{decimalTokenBalance}
                             </Text>
                         )}
                     </MaxGapRow>

--- a/frontend/src/helpers/fee.ts
+++ b/frontend/src/helpers/fee.ts
@@ -5,9 +5,9 @@ const CCD_DECIMALS = 6;
 const microCcdToCcd = (number: BigNumberish) => ethers.utils.formatUnits(number, CCD_DECIMALS);
 
 export const renderGasFeeEstimate = (fee: number, ethPrice: number): string =>
-    `~${fee.toFixed(4)} ETH (${(fee * ethPrice).toFixed(4)} USD)`;
+    `~${fee.toFixed(8)} ETH (~${(fee * ethPrice).toFixed(4)} USD)`;
 
 export const renderEnergyFeeEstimate = (microCcdFee: bigint, ccdPrice: number): string => {
     const ccdFee = Number(microCcdToCcd(microCcdFee));
-    return `~${ccdFee.toFixed(4)} CCD (${(ccdFee * ccdPrice).toFixed(4)} USD)`;
+    return `~${ccdFee.toFixed(4)} CCD (~${(ccdFee * ccdPrice).toFixed(4)} USD)`;
 };


### PR DESCRIPTION
## Purpose

- Removes rounding for balance visible on transfers page
- Correctly sets max to available balance for selected token
- Laxed rounding for transaction estimates on overview pages
- Show all decimals on transfer progress page
- Remove reset state for transfer page when applied

Closes #71 Closes #67 Closes #76 
