### PR TITLE
Frontend/history fixes

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 - For withdrawals, the expected time of the next merkle root, i.e. when the next round of withdrawals will be ready for approval, is now displayed instead of statically showing 10 minute processing time.
 - Provide a full overview of the transactions (and corresponding fees) required to execute a full withdrawal/desposit.
+- Submitted transactions are now stored in the browser's storage upon submission, to allow users to see them instantly in the transaction history.
 
 ### Fixes
 - A number of minor bugs

--- a/frontend/pages/deposit/overview.tsx
+++ b/frontend/pages/deposit/overview.tsx
@@ -16,6 +16,7 @@ import { noOp } from "src/helpers/basic";
 import { getPrice } from "src/helpers/price-usd";
 import { Components } from "src/api-query/__generated__/AxiosClient";
 import { renderGasFeeEstimate } from "src/helpers/fee";
+import { useSubmittedDepositsStore } from "src/store/submitted-transactions";
 
 const LINE_DETAILS_FALLBACK = "...";
 
@@ -123,6 +124,7 @@ const DepositOverview: NextPage = () => {
     const { prefetch } = useRouter();
     const { status, setInfo, setError } = useTransferOverviewStatusState();
     const { replace } = useRouter();
+    const { add: addSubmitted } = useSubmittedDepositsStore();
     const ethPrice = useAsyncMemo(async () => getPrice("ETH"), noOp, []) ?? 0;
     const isErc20 = token?.eth_address !== addresses.eth;
     const erc20PredicateAddress = useAsyncMemo(async () => (isErc20 ? typeToVault() : undefined), noOp, [token]);
@@ -189,6 +191,7 @@ const DepositOverview: NextPage = () => {
 
             setInfo("Waiting for transaction to finalize");
             await tx.wait(1); // wait for confirmed transaction
+            addSubmitted(tx.hash.replace("0x", ""), amount, token);
 
             return routes.deposit.tx(tx.hash);
         } catch (error) {

--- a/frontend/pages/withdraw/[tx].tsx
+++ b/frontend/pages/withdraw/[tx].tsx
@@ -32,7 +32,7 @@ const WithdrawTransactionStatus: NextPage = () => {
 
     useEffect(() => {
         if (tx === undefined && isReady) {
-            replace(routes.deposit.path);
+            replace(routes.withdraw.path);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/frontend/pages/withdraw/overview.tsx
+++ b/frontend/pages/withdraw/overview.tsx
@@ -21,6 +21,7 @@ import transactionCosts from "@config/transaction-cost";
 import useRootManagerContract from "src/contracts/use-root-manager";
 import { renderEnergyFeeEstimate, renderGasFeeEstimate } from "src/helpers/fee";
 import Text from "src/components/atoms/text/text";
+import { useSubmittedWithdrawalsStore } from "src/store/submitted-transactions";
 
 const LINE_DETAILS_FALLBACK = "...";
 
@@ -155,6 +156,7 @@ const WithdrawOverview: NextPage = () => {
     const [needsAllowance, setNeedsAllowance] = useState<boolean | undefined>();
     const ccdPrice = useAsyncMemo(async () => getPrice("CCD"), noOp, []) ?? 0;
     const microCcdPerEnergy = useAsyncMemo(getEnergyToMicroCcdRate, noOp, []);
+    const { add: addSubmitted } = useSubmittedWithdrawalsStore();
 
     const {
         withdraw: ccdWithdraw,
@@ -248,6 +250,7 @@ const WithdrawOverview: NextPage = () => {
         try {
             setInfo("Waiting for transaction to finalize");
             await transactionFinalization(hash); // Wait for transaction finalization, as we do in the deposit flow.
+            addSubmitted(hash, amount, token);
 
             return routes.withdraw.tx(hash);
         } catch {

--- a/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
+++ b/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
@@ -134,7 +134,7 @@ export const TransferProgress: React.FC<Props> = (props) => {
 
             await props.onRequestApproval(setError, setInfo);
         } else {
-            push({ pathname: routes.deposit.path, query: { reset: true } });
+            push({ pathname: isWithdraw ? routes.withdraw.path : routes.deposit.path, query: { reset: true } });
             clearFlowStore();
         }
     };

--- a/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
+++ b/frontend/src/components/templates/transfer-progress/TransferProgress.tsx
@@ -24,7 +24,7 @@ import { QueryRouter } from "src/types/config";
 import isDeposit from "src/helpers/checkTransaction";
 import { useGetTransactionToken } from "@hooks/use-transaction-token";
 import { useWalletTransactions } from "src/api-query/queries";
-import { ethers } from "ethers";
+import { toFractionalAmount } from "src/helpers/number";
 
 type Status = {
     message: string;
@@ -121,7 +121,7 @@ export const TransferProgress: React.FC<Props> = (props) => {
             return undefined;
         }
 
-        return ethers.utils.formatUnits(amount, token.decimals);
+        return toFractionalAmount(amount, token.decimals);
     }, [amount, token]);
 
     const setError = (message: string) => setStatus({ isError: true, message });

--- a/frontend/src/components/templates/transfer/Transfer.tsx
+++ b/frontend/src/components/templates/transfer/Transfer.tsx
@@ -44,6 +44,7 @@ import {
     SwapLink,
 } from "./Transfer.style";
 import { ethers } from "ethers";
+import { toFractionalAmount } from "src/helpers/number";
 
 interface ChainType {
     id: number;
@@ -159,14 +160,7 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
                 throw new Error("Token expected to be available");
             }
 
-            const formatted = ethers.utils.formatUnits(amount, token.decimals);
-            const [whole, fraction] = formatted.split(".");
-
-            if (fraction === "0") {
-                return whole;
-            }
-
-            return formatted;
+            return toFractionalAmount(amount, token.decimals);
         },
         [token]
     );

--- a/frontend/src/components/templates/transfer/Transfer.tsx
+++ b/frontend/src/components/templates/transfer/Transfer.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useTokens } from "src/api-query/queries";
 import { Components } from "src/api-query/__generated__/AxiosClient";
-import { routes } from "src/constants/routes";
+import { BridgeDirection, routes } from "src/constants/routes";
 import useCCDContract from "src/contracts/use-ccd-contract";
 import useGenerateContract from "src/contracts/use-generate-contract";
 import { noOp } from "src/helpers/basic";
@@ -368,7 +368,11 @@ const Transfer: React.FC<Props> = ({ isDeposit = false }) => {
                 </Button>
             </StyledContainer>
             {context?.account && (
-                <Link href={routes.history()} passHref legacyBehavior>
+                <Link
+                    href={routes.history(isDeposit ? BridgeDirection.Deposit : BridgeDirection.Withdraw)}
+                    passHref
+                    legacyBehavior
+                >
                     <LinkWrapper>
                         <Text fontSize="12" fontFamily="Roboto" fontColor="Brown">
                             Transaction History

--- a/frontend/src/helpers/number.ts
+++ b/frontend/src/helpers/number.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { BigNumberish, ethers } from "ethers";
 
 /**
  *
@@ -8,3 +8,14 @@ import { ethers } from "ethers";
 export const toWei = (amount: string): string => ethers.utils.parseEther(amount).toString();
 
 export const formatAmount = (decimalNumber: string) => Math.round(+decimalNumber * 1e4) / 1e4;
+
+export const toFractionalAmount = (integerAmount: BigNumberish, decimals: number) => {
+    const formatted = ethers.utils.formatUnits(integerAmount, decimals);
+    const [whole, fractions] = formatted.split(".");
+
+    if (fractions === "0") {
+        return whole;
+    }
+
+    return formatted;
+};

--- a/frontend/src/store/approved-withdraws.ts
+++ b/frontend/src/store/approved-withdraws.ts
@@ -19,6 +19,6 @@ export const useApprovedWithdrawalsStore = create(
                 set({ transactions: ts });
             },
         }),
-        { name: "eth-ccd-bridge" }
+        { name: "eth-ccd-bridge.approved-withdrawals" }
     )
 );

--- a/frontend/src/store/submitted-transactions.ts
+++ b/frontend/src/store/submitted-transactions.ts
@@ -1,0 +1,43 @@
+import { BigNumberish } from "ethers";
+import { Components } from "src/api-query/__generated__/AxiosClient";
+import create, { StateCreator } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type SubmittedTransaction = {
+    hash: string;
+    /** Integer */
+    amount: string;
+    token: Components.Schemas.TokenMapItem;
+    /** In seconds */
+    timestamp: number;
+};
+
+type SubmittedTransactionsStore = {
+    transactions: SubmittedTransaction[];
+    add(transactionHash: string, amount: BigNumberish, token: Components.Schemas.TokenMapItem): void;
+};
+
+const storeCreator: StateCreator<SubmittedTransactionsStore> = (set, get) => ({
+    transactions: [],
+    add: (hash, amount, token) =>
+        set({
+            transactions: [
+                ...get().transactions,
+                { hash, amount: amount.toString(), token, timestamp: Math.floor(Date.now() / 1000) },
+            ],
+        }),
+});
+
+export const useSubmittedDepositsStore = create(
+    persist<SubmittedTransactionsStore>(storeCreator, {
+        name: "eth-ccd-bridge.submitted-deposits",
+        getStorage: () => window.sessionStorage,
+    })
+);
+
+export const useSubmittedWithdrawalsStore = create(
+    persist<SubmittedTransactionsStore>(storeCreator, {
+        name: "eth-ccd-bridge.submitted-withdrawals",
+        getStorage: () => window.sessionStorage,
+    })
+);


### PR DESCRIPTION
## Purpose

This PR addresses bugs and missing functionality in the transaction history of the bridge frontend.

## Changes

- Adds transactions to local browser storage on submission, to allow users to see pending transactions in history prior to the bridge relayer picking them up
- Withdraw routes are now used instead of a mix of deposit/withdraw routes when the user is in withdraw context
- Transaction history is now sorted (most recent transactions shown first)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
