### PR TITLE
Show warning when trying to cancel transaction flow

### DIFF
--- a/frontend/pages/deposit/overview.tsx
+++ b/frontend/pages/deposit/overview.tsx
@@ -126,6 +126,7 @@ const DepositOverview: NextPage = () => {
     const ethPrice = useAsyncMemo(async () => getPrice("ETH"), noOp, []) ?? 0;
     const isErc20 = token?.eth_address !== addresses.eth;
     const erc20PredicateAddress = useAsyncMemo(async () => (isErc20 ? typeToVault() : undefined), noOp, [token]);
+    const [pendingSignature, setPendingSignature] = useState(false);
 
     useEffect(() => {
         if (!isErc20) {
@@ -148,8 +149,10 @@ const DepositOverview: NextPage = () => {
         }
 
         try {
+            setPendingSignature(true);
             setInfo("Requesting allowance from Ethereum wallet.");
             const tx = await checkAllowance(erc20PredicateAddress);
+            setPendingSignature(false);
 
             setInfo("Waiting for transaction to finalize");
             await tx.wait(1);
@@ -159,6 +162,8 @@ const DepositOverview: NextPage = () => {
         } catch {
             // TODO: log actual error
             setError("Allowance request rejected");
+            setPendingSignature(false);
+
             return false;
         }
     };
@@ -177,6 +182,7 @@ const DepositOverview: NextPage = () => {
         }
 
         try {
+            setPendingSignature(true);
             setInfo("Awaiting signature of deposit in Ethereum wallet");
             let tx: ContractTransaction;
             if (token.eth_address === addresses.eth) {
@@ -184,6 +190,7 @@ const DepositOverview: NextPage = () => {
             } else {
                 tx = await depositFor(amount, token); //deposit
             }
+            setPendingSignature(false);
 
             prefetch(routes.deposit.tx(tx.hash));
 
@@ -192,6 +199,7 @@ const DepositOverview: NextPage = () => {
 
             return routes.deposit.tx(tx.hash);
         } catch (error) {
+            setPendingSignature(false);
             // TODO: log actual error
             if (error.message.includes(errors.ACTION_REJECTED)) {
                 setError("Transaction was rejected.");
@@ -207,6 +215,8 @@ const DepositOverview: NextPage = () => {
             handleSubmit={onSubmit}
             timeToComplete="Deposit should take up to 5 minutes to complete."
             status={status}
+            pendingWalletSignature={pendingSignature}
+            isDeposit
         >
             {isErc20 && (
                 <>

--- a/frontend/pages/withdraw/overview.tsx
+++ b/frontend/pages/withdraw/overview.tsx
@@ -155,6 +155,7 @@ const WithdrawOverview: NextPage = () => {
     const [needsAllowance, setNeedsAllowance] = useState<boolean | undefined>();
     const ccdPrice = useAsyncMemo(async () => getPrice("CCD"), noOp, []) ?? 0;
     const microCcdPerEnergy = useAsyncMemo(getEnergyToMicroCcdRate, noOp, []);
+    const [pendingSignature, setPendingSignature] = useState(false);
 
     const {
         withdraw: ccdWithdraw,
@@ -204,8 +205,10 @@ const WithdrawOverview: NextPage = () => {
         try {
             const approvalFee = await estimateApprove(token);
 
+            setPendingSignature(true);
             setInfo("Awaiting allowance approval in Concordium wallet");
             const hash = await ccdApprove(token, approvalFee?.conservative);
+            setPendingSignature(false);
 
             setInfo("Waiting for transaction to finalize");
             const hasApproval = await transactionFinalization(hash);
@@ -214,7 +217,9 @@ const WithdrawOverview: NextPage = () => {
             return hasApproval;
         } catch {
             // Either the allowance approval was rejected, or a timeout happened while polling for allowance approval finalization
+            setPendingSignature(false);
             setError("Allowance appproval rejected");
+
             return false;
         }
     };
@@ -235,11 +240,14 @@ const WithdrawOverview: NextPage = () => {
         try {
             const withdrawFee = await estimateWithdraw(amount, token, context.account || "");
 
+            setPendingSignature(true);
             setInfo("Awaiting signature of withdrawal in Concordium wallet");
             hash = await ccdWithdraw(amount, token, context?.account || "", withdrawFee?.conservative);
             prefetch(routes.withdraw.tx(hash));
         } catch {
             setError("Transaction was rejected.");
+        } finally {
+            setPendingSignature(false);
         }
 
         if (hash === undefined) {
@@ -261,6 +269,7 @@ const WithdrawOverview: NextPage = () => {
             handleSubmit={onSubmit}
             timeToComplete={timeToComplete}
             status={status}
+            pendingWalletSignature={pendingSignature}
         >
             <ApprovalAllowanceLine
                 hasAllowance={needsAllowance === false}

--- a/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
+++ b/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
@@ -104,11 +104,15 @@ export const TransferOverview: FC<PropsWithChildren<Props>> = ({
 
     const cancel = () => {
         if (pendingWalletSignature) {
-            window.alert(
+            const confirmed = window.confirm(
                 `There is a pending wallet signature in your ${
                     isDeposit ? "Ethereum" : "Concordium"
                 } wallet, which can be safely rejected when cancelling this flow.`
             );
+
+            if (!confirmed) {
+                return;
+            }
         }
 
         back();

--- a/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
+++ b/frontend/src/components/templates/transfer-overview/TransferOverview.tsx
@@ -60,9 +60,24 @@ type Props = {
      * Expects route of next page to be returned, or undefined if an error happened.
      */
     handleSubmit(): Promise<string | undefined>;
+    /**
+     * Status message to be shown on page. Can either be shown as an error, or plain information.
+     */
     status?: TransferOverviewStatus;
+    /**
+     * Title of the overview page
+     */
     title: string;
+    /**
+     * Estimated time required to complete flow in text.
+     */
     timeToComplete: string;
+    /**
+     * When true, will show a prompt when pressing cancel,
+     * warning the user that there is a pending signature request in the corresponding wallet.
+     */
+    pendingWalletSignature: boolean;
+    isDeposit?: boolean;
 };
 
 export const TransferOverview: FC<PropsWithChildren<Props>> = ({
@@ -70,6 +85,8 @@ export const TransferOverview: FC<PropsWithChildren<Props>> = ({
     status,
     title,
     timeToComplete,
+    pendingWalletSignature,
+    isDeposit = false,
     children,
 }) => {
     const [pendingSubmission, setPendingSubmission] = useState(false);
@@ -83,6 +100,18 @@ export const TransferOverview: FC<PropsWithChildren<Props>> = ({
         if (nextRoute) {
             push(nextRoute);
         }
+    };
+
+    const cancel = () => {
+        if (pendingWalletSignature) {
+            window.alert(
+                `There is a pending wallet signature in your ${
+                    isDeposit ? "Ethereum" : "Concordium"
+                } wallet, which can be safely rejected when cancelling this flow.`
+            );
+        }
+
+        back();
     };
 
     return (
@@ -119,7 +148,7 @@ export const TransferOverview: FC<PropsWithChildren<Props>> = ({
                     {status ? status.message : <>&nbsp;</>}
                 </Text>
                 <ButtonsContainer>
-                    <Button variant="secondary" onClick={back}>
+                    <Button variant="secondary" onClick={cancel}>
                         <div style={{ position: "relative" }}>
                             <Text fontSize="16" fontColor="Black" fontWeight="bold">
                                 Cancel


### PR DESCRIPTION
## Purpose

An attempt to help users avoid confusing situations with multiple signature requests in their wallet.

The corresponding issue is #84 

## Changes

- Show a prompt when trying to cancel a transaction flow, while there is a signature request is pending in either ccd/eth wallet.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
